### PR TITLE
Bootstrap TypeScript CLI + Makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+node_modules/
+dist/
+.DS_Store
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,28 @@
+.PHONY: help install clean build typecheck dev start
+
+help:
+	@echo 'Targets:'
+	@echo '  make install     Install npm dependencies'
+	@echo '  make dev         Run the game in dev mode (TypeScript)'
+	@echo '  make build       Build to ./dist'
+	@echo '  make start       Run the built game (JavaScript)'
+	@echo '  make typecheck   Type-check without emitting'
+	@echo '  make clean       Remove build output'
+
+install:
+	npm install
+
+clean:
+	npm run clean
+
+build:
+	npm run build
+
+typecheck:
+	npm run typecheck
+
+dev:
+	npm run dev
+
+start:
+	npm run start

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ install:
 	npm install
 
 clean:
-	rm -rf dist
+	node -e "require('node:fs').rmSync('dist', { recursive: true, force: true })"
 
 build:
 	$(MAKE) clean

--- a/Makefile
+++ b/Makefile
@@ -13,16 +13,17 @@ install:
 	npm install
 
 clean:
-	npm run clean
+	rm -rf dist
 
 build:
-	npm run build
+	$(MAKE) clean
+	npm exec -- tsc -p tsconfig.json
 
 typecheck:
-	npm run typecheck
+	npm exec -- tsc -p tsconfig.json --noEmit
 
 dev:
-	npm run dev
+	npm exec -- tsx src/index.ts
 
 start:
-	npm run start
+	node dist/index.js

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,12 @@
-.PHONY: help install clean build typecheck dev start
+.PHONY: help setup install clean build typecheck dev start
+
+ENTRY_TS := src/index.ts
+ENTRY_JS := dist/index.js
+DIST_DIR := dist
 
 help:
 	@echo 'Targets:'
+	@echo '  make setup       Install deps and build'
 	@echo '  make install     Install npm dependencies'
 	@echo '  make dev         Run the game in dev mode (TypeScript)'
 	@echo '  make build       Build to ./dist'
@@ -9,21 +14,22 @@ help:
 	@echo '  make typecheck   Type-check without emitting'
 	@echo '  make clean       Remove build output'
 
+setup: install build
+
 install:
 	npm install
 
 clean:
-	node -e "require('node:fs').rmSync('dist', { recursive: true, force: true })"
+	rm -rf $(DIST_DIR)
 
-build:
-	$(MAKE) clean
+build: clean
 	npm exec -- tsc -p tsconfig.json
 
 typecheck:
 	npm exec -- tsc -p tsconfig.json --noEmit
 
 dev:
-	npm exec -- tsx src/index.ts
+	npm exec -- tsx $(ENTRY_TS)
 
 start:
-	node dist/index.js
+	node $(ENTRY_JS)

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,5 @@
 .PHONY: help setup install clean build typecheck dev start
 
-ENTRY_TS := src/index.ts
-ENTRY_JS := dist/index.js
-DIST_DIR := dist
-
 help:
 	@echo 'Targets:'
 	@echo '  make setup       Install deps and build'
@@ -14,22 +10,23 @@ help:
 	@echo '  make typecheck   Type-check without emitting'
 	@echo '  make clean       Remove build output'
 
-setup: install build
+setup:
+	npm run setup
 
 install:
 	npm install
 
 clean:
-	rm -rf $(DIST_DIR)
+	npm run clean
 
-build: clean
-	npm exec -- tsc -p tsconfig.json
+build:
+	npm run build
 
 typecheck:
-	npm exec -- tsc -p tsconfig.json --noEmit
+	npm run typecheck
 
 dev:
-	npm exec -- tsx $(ENTRY_TS)
+	npm run dev
 
 start:
-	node $(ENTRY_JS)
+	npm run start

--- a/Makefile
+++ b/Makefile
@@ -10,8 +10,7 @@ help:
 	@echo '  make typecheck   Type-check without emitting'
 	@echo '  make clean       Remove build output'
 
-setup:
-	npm run setup
+setup: install build
 
 install:
 	npm install

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Procedural TypeScript command line text adventure.
 ## Dev
 
 ```bash
-make install
+make setup
 make dev
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,16 @@
+
+Procedural TypeScript command line text adventure.
+
+## Dev
+
+```bash
+make install
+make dev
+```
+
+## Build + run
+
+```bash
+make build
+make start
+```

--- a/README.md
+++ b/README.md
@@ -1,7 +1,20 @@
 
 Procedural TypeScript command line text adventure.
 
+## Prerequisites
+
+- Node.js (ESM)
+- npm
+- (optional) `make` for the Makefile workflow
+
 ## Dev
+
+```bash
+npm install
+npm run dev
+```
+
+Or, with `make`:
 
 ```bash
 make setup
@@ -9,6 +22,13 @@ make dev
 ```
 
 ## Build + run
+
+```bash
+npm run build
+npm start
+```
+
+Or, with `make`:
 
 ```bash
 make build

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,594 @@
+{
+  "name": "dk",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "dk",
+      "version": "0.0.0",
+      "license": "UNLICENSED",
+      "bin": {
+        "dk": "dist/index.js"
+      },
+      "devDependencies": {
+        "@types/node": "^25.3.2",
+        "tsx": "^4.21.0",
+        "typescript": "^5.9.3"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.3.tgz",
+      "integrity": "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.3.tgz",
+      "integrity": "sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.3.tgz",
+      "integrity": "sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.3.tgz",
+      "integrity": "sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.3.tgz",
+      "integrity": "sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.3.tgz",
+      "integrity": "sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.3.tgz",
+      "integrity": "sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.3.tgz",
+      "integrity": "sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.3.tgz",
+      "integrity": "sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.3.tgz",
+      "integrity": "sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.3.tgz",
+      "integrity": "sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.3.tgz",
+      "integrity": "sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.3.tgz",
+      "integrity": "sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.3.tgz",
+      "integrity": "sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.3.tgz",
+      "integrity": "sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.3.tgz",
+      "integrity": "sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.3.tgz",
+      "integrity": "sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.3.tgz",
+      "integrity": "sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.3.tgz",
+      "integrity": "sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.3.tgz",
+      "integrity": "sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.3.tgz",
+      "integrity": "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "25.3.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.3.2.tgz",
+      "integrity": "sha512-RpV6r/ij22zRRdyBPcxDeKAzH43phWVKEjL2iksqo1Vz3CuBUrgmPpPhALKiRfU7OMCmeeO9vECBMsV0hMTG8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.18.0"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
+      "integrity": "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.3",
+        "@esbuild/android-arm": "0.27.3",
+        "@esbuild/android-arm64": "0.27.3",
+        "@esbuild/android-x64": "0.27.3",
+        "@esbuild/darwin-arm64": "0.27.3",
+        "@esbuild/darwin-x64": "0.27.3",
+        "@esbuild/freebsd-arm64": "0.27.3",
+        "@esbuild/freebsd-x64": "0.27.3",
+        "@esbuild/linux-arm": "0.27.3",
+        "@esbuild/linux-arm64": "0.27.3",
+        "@esbuild/linux-ia32": "0.27.3",
+        "@esbuild/linux-loong64": "0.27.3",
+        "@esbuild/linux-mips64el": "0.27.3",
+        "@esbuild/linux-ppc64": "0.27.3",
+        "@esbuild/linux-riscv64": "0.27.3",
+        "@esbuild/linux-s390x": "0.27.3",
+        "@esbuild/linux-x64": "0.27.3",
+        "@esbuild/netbsd-arm64": "0.27.3",
+        "@esbuild/netbsd-x64": "0.27.3",
+        "@esbuild/openbsd-arm64": "0.27.3",
+        "@esbuild/openbsd-x64": "0.27.3",
+        "@esbuild/openharmony-arm64": "0.27.3",
+        "@esbuild/sunos-x64": "0.27.3",
+        "@esbuild/win32-arm64": "0.27.3",
+        "@esbuild/win32-ia32": "0.27.3",
+        "@esbuild/win32-x64": "0.27.3"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.13.6",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.6.tgz",
+      "integrity": "sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,6 @@
       "name": "dk",
       "version": "0.0.0",
       "license": "UNLICENSED",
-      "bin": {
-        "dk": "dist/index.js"
-      },
       "devDependencies": {
         "@types/node": "^25.3.2",
         "tsx": "^4.21.0",

--- a/package.json
+++ b/package.json
@@ -6,11 +6,12 @@
   "description": "Procedural TypeScript command line text adventure.",
   "license": "UNLICENSED",
   "scripts": {
-    "clean": "make clean",
-    "build": "make build",
-    "typecheck": "make typecheck",
-    "dev": "make dev",
-    "start": "make start"
+    "setup": "npm install && npm run build",
+    "clean": "node scripts/clean.mjs",
+    "build": "npm run clean && tsc -p tsconfig.json",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "dev": "tsx src/index.ts",
+    "start": "node dist/index.js"
   },
   "devDependencies": {
     "@types/node": "^25.3.2",

--- a/package.json
+++ b/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "dk",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Procedural TypeScript command line text adventure.",
+  "license": "UNLICENSED",
+  "scripts": {
+    "clean": "rm -rf dist",
+    "build": "npm run clean && tsc -p tsconfig.json",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "dev": "tsx src/index.ts",
+    "start": "node dist/index.js"
+  },
+  "devDependencies": {
+    "@types/node": "^25.3.2",
+    "tsx": "^4.21.0",
+    "typescript": "^5.9.3"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -5,11 +5,11 @@
   "description": "Procedural TypeScript command line text adventure.",
   "license": "UNLICENSED",
   "scripts": {
-    "clean": "rm -rf dist",
-    "build": "npm run clean && tsc -p tsconfig.json",
-    "typecheck": "tsc -p tsconfig.json --noEmit",
-    "dev": "tsx src/index.ts",
-    "start": "node dist/index.js"
+    "clean": "make clean",
+    "build": "make build",
+    "typecheck": "make typecheck",
+    "dev": "make dev",
+    "start": "make start"
   },
   "devDependencies": {
     "@types/node": "^25.3.2",

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "dk",
   "version": "0.0.0",
   "private": true,
+  "type": "module",
   "description": "Procedural TypeScript command line text adventure.",
   "license": "UNLICENSED",
   "scripts": {

--- a/scripts/clean.mjs
+++ b/scripts/clean.mjs
@@ -1,0 +1,3 @@
+import { rmSync } from 'node:fs';
+
+rmSync(new URL('../dist', import.meta.url), { recursive: true, force: true });

--- a/scripts/clean.mjs
+++ b/scripts/clean.mjs
@@ -1,3 +1,4 @@
 import { rmSync } from 'node:fs';
+import { resolve } from 'node:path';
 
-rmSync(new URL('../dist', import.meta.url), { recursive: true, force: true });
+rmSync(resolve(process.cwd(), 'dist'), { recursive: true, force: true });

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -2,11 +2,15 @@ import { stdout } from 'node:process';
 
 export type CommandResult = 'continue' | 'exit';
 
-export function handleCommand(input: string): CommandResult {
-  if (input === 'quit' || input === 'exit') return 'exit';
+const BASE_COMMANDS = ['help', 'quit', 'exit'] as const;
 
-  if (input === 'help') {
-    stdout.write('Commands: help, quit, exit\n');
+export function handleCommand(input: string): CommandResult {
+  const cmd = input.trim().toLowerCase();
+
+  if (cmd === 'quit' || cmd === 'exit') return 'exit';
+
+  if (cmd === 'help') {
+    stdout.write(`Commands: ${BASE_COMMANDS.join(', ')}\n`);
     return 'continue';
   }
 

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -1,0 +1,15 @@
+import { stdout } from 'node:process';
+
+export type CommandResult = 'continue' | 'exit';
+
+export function handleCommand(input: string): CommandResult {
+  if (input === 'quit' || input === 'exit') return 'exit';
+
+  if (input === 'help') {
+    stdout.write('Commands: help, quit, exit\n');
+    return 'continue';
+  }
+
+  stdout.write(`Unknown command: ${input}. Type "help".\n`);
+  return 'continue';
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,11 +21,13 @@ async function main(): Promise<void> {
       "Type 'help' for commands, or 'quit'/'exit' to leave the game. Story content will be added later.\n\n",
     );
 
-    while (true) {
+    let running = true;
+    while (running) {
       let input: string;
       try {
         input = (await rl.question('> ')).trim();
       } catch {
+        stdout.write('\nGoodbye!\n');
         break;
       }
 
@@ -33,7 +35,7 @@ async function main(): Promise<void> {
 
       try {
         const result: CommandResult = handleCommand(input);
-        if (result === 'exit') break;
+        if (result === 'exit') running = false;
       } catch (err) {
         console.error('Command error:', err instanceof Error ? err.message : String(err));
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,32 @@
+import { createInterface } from 'node:readline/promises';
+import { stdin, stdout } from 'node:process';
+
+async function main(): Promise<void> {
+  const rl = createInterface({ input: stdin, output: stdout });
+
+  stdout.write('DK — procedural TypeScript text adventure\n');
+  stdout.write('Type "help" for commands, or "quit" to exit.\n\n');
+
+  try {
+    while (true) {
+      const input = (await rl.question('> ')).trim();
+
+      if (input === '') continue;
+      if (input === 'quit' || input === 'exit') break;
+
+      if (input === 'help') {
+        stdout.write('Commands: help, quit\n');
+        continue;
+      }
+
+      stdout.write(`You said: ${input}\n`);
+    }
+  } finally {
+    rl.close();
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exitCode = 1;
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,12 +4,14 @@ import { stdin, stdout } from 'node:process';
 type CommandResult = 'continue' | 'exit';
 
 function handleCommand(input: string): CommandResult {
+  if (input === 'quit' || input === 'exit') return 'exit';
+
   if (input === 'help') {
     stdout.write('Commands: help, quit\n');
     return 'continue';
   }
 
-  stdout.write(`You said: ${input}\n`);
+  stdout.write(`Unknown command: ${input}. Type "help".\n`);
   return 'continue';
 }
 
@@ -33,7 +35,6 @@ async function main(): Promise<void> {
       const input = (await rl.question('> ')).trim();
 
       if (input === '') continue;
-      if (input === 'quit' || input === 'exit') break;
 
       const result = handleCommand(input);
       if (result === 'exit') break;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,27 @@
 import { createInterface } from 'node:readline/promises';
 import { stdin, stdout } from 'node:process';
 
+type CommandResult = 'continue' | 'exit';
+
+function handleCommand(input: string): CommandResult {
+  if (input === 'help') {
+    stdout.write('Commands: help, quit\n');
+    return 'continue';
+  }
+
+  stdout.write(`You said: ${input}\n`);
+  return 'continue';
+}
+
+function handleFatalError(err: unknown): void {
+  if (err instanceof Error) {
+    console.error(err.message);
+    return;
+  }
+
+  console.error(String(err));
+}
+
 async function main(): Promise<void> {
   const rl = createInterface({ input: stdin, output: stdout });
 
@@ -14,12 +35,8 @@ async function main(): Promise<void> {
       if (input === '') continue;
       if (input === 'quit' || input === 'exit') break;
 
-      if (input === 'help') {
-        stdout.write('Commands: help, quit\n');
-        continue;
-      }
-
-      stdout.write(`You said: ${input}\n`);
+      const result = handleCommand(input);
+      if (result === 'exit') break;
     }
   } finally {
     rl.close();
@@ -27,6 +44,6 @@ async function main(): Promise<void> {
 }
 
 main().catch((err) => {
-  console.error(err);
+  handleFatalError(err);
   process.exitCode = 1;
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,43 +1,42 @@
 import { createInterface } from 'node:readline/promises';
 import { stdin, stdout } from 'node:process';
 
-type CommandResult = 'continue' | 'exit';
-
-function handleCommand(input: string): CommandResult {
-  if (input === 'quit' || input === 'exit') return 'exit';
-
-  if (input === 'help') {
-    stdout.write('Commands: help, quit\n');
-    return 'continue';
-  }
-
-  stdout.write(`Unknown command: ${input}. Type "help".\n`);
-  return 'continue';
-}
+import { type CommandResult, handleCommand } from './commands.js';
 
 function handleFatalError(err: unknown): void {
   if (err instanceof Error) {
-    console.error(err.message);
+    console.error('Fatal error:', err.stack ?? err.message);
     return;
   }
 
-  console.error(String(err));
+  console.error('Fatal error:', String(err));
 }
 
 async function main(): Promise<void> {
   const rl = createInterface({ input: stdin, output: stdout });
 
-  stdout.write('DK — procedural TypeScript text adventure\n');
-  stdout.write('Type "help" for commands, or "quit" to exit.\n\n');
-
   try {
+    stdout.write('DK — procedural TypeScript text adventure (bootstrap)\n');
+    stdout.write(
+      "Type 'help' for commands, or 'quit'/'exit' to leave the game. Story content will be added later.\n\n",
+    );
+
     while (true) {
-      const input = (await rl.question('> ')).trim();
+      let input: string;
+      try {
+        input = (await rl.question('> ')).trim();
+      } catch {
+        break;
+      }
 
       if (input === '') continue;
 
-      const result = handleCommand(input);
-      if (result === 'exit') break;
+      try {
+        const result: CommandResult = handleCommand(input);
+        if (result === 'exit') break;
+      } catch (err) {
+        console.error('Command error:', err instanceof Error ? err.message : String(err));
+      }
     }
   } finally {
     rl.close();

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,7 +28,8 @@ async function main(): Promise<void> {
         input = (await rl.question('> ')).trim();
       } catch {
         stdout.write('\nGoodbye!\n');
-        break;
+        running = false;
+        continue;
       }
 
       if (input === '') continue;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
     "target": "ES2022",
-    "module": "CommonJS",
-    "moduleResolution": "node",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
     "lib": ["ES2022"],
     "types": ["node"],
     "rootDir": "src",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,9 @@
   "compilerOptions": {
     "target": "ES2022",
     "module": "CommonJS",
+    "moduleResolution": "node",
     "lib": ["ES2022"],
+    "types": ["node"],
     "rootDir": "src",
     "outDir": "dist",
     "strict": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "CommonJS",
+    "lib": ["ES2022"],
+    "rootDir": "src",
+    "outDir": "dist",
+    "strict": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "sourceMap": true
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
Bootstraps `dk` as a Node (ESM) + TypeScript CLI project with a minimal interactive shell, and adds a `Makefile` to make common tasks easy.

### Changes

- Add TypeScript toolchain (`tsconfig.json`, `package.json` scripts, dev deps).
- Add a small CLI shell (`src/index.ts`) plus a tiny command handler (`src/commands.ts`).
- Add `Makefile` wrappers, `.gitignore`, and a small `scripts/clean.mjs` helper.

### Verification

```bash
$ npm run typecheck
$ npm run build
```

- No lint/test tooling is configured yet (out of scope for this bootstrap).
- reviewChanges skipped: minor suggestions around further de-duplication/normalization/logging abstractions — keeping this as a small baseline.

Closes #1.